### PR TITLE
#32 一般公開ページで次の検索、絞り込み

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,9 +1,10 @@
 class UsersController < ApplicationController
   def index
-    @users = User.page(params[:page]).per(params[:per_page])
-    @users = @users.where("name LIKE ?", "%#{params[:name]}%") if params[:name].present?
-    @users = @users.where(address1: params[:address1]) if params[:address1].present?
-    @users = @users.order(birthday: params[:birthday]) if params[:birthday].present?
+    @per_page = params[:per_page]
+    @name = params[:name]
+    @address1 = params[:address1]
+    @order = params[:order]
+    @users = User.page(params[:page]).per(@per_page).search_name(@name).search_address1(@address1).order_by(@order)
   end
   
   def show

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,7 @@ class UsersController < ApplicationController
     @users = User.page(params[:page]).per(params[:per_page])
     @users = @users.where("name LIKE ?", "%#{params[:name]}%") if params[:name].present?
     @users = @users.where(address1: params[:address1]) if params[:address1].present?
-    @users = @users.order(birthday: params[:birthday].to_sym) if params[:birthday].present?
+    @users = @users.order(birthday: params[:birthday]) if params[:birthday].present?
   end
   
   def show

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,11 +1,9 @@
 class UsersController < ApplicationController
   def index
-    @users = User.all
-    @users = @users.where("name LIKE ?", "%#{params[:user_name_search]}%") if params[:user_name_search].present?
-    @users = @users.where(address1: params[:user_address1_search]) if params[:user_address1_search].present?
-    @users = @users.order(birthday: :desc) if params[:birthday_sort] == "latest"
-    @users = @users.order(birthday: :asc) if params[:birthday_sort] == "oldest"
-    @users = @users.page(params[:page]).per(params[:per_page])
+    @users = User.page(params[:page]).per(params[:per_page])
+    @users = @users.where("name LIKE ?", "%#{params[:name]}%") if params[:name].present?
+    @users = @users.where(address1: params[:address1]) if params[:address1].present?
+    @users = @users.order(birthday: params[:birthday].to_sym) if params[:birthday].present?
   end
   
   def show

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,10 +1,15 @@
 class UsersController < ApplicationController
-    def index
-      @users = User.page(params[:page])
-    end
+  def index
+    @users = User.all
+    @users = @users.where("name LIKE ?", "%#{params[:user_name_search]}%") if params[:user_name_search].present?
+    @users = @users.where(address1: params[:user_address1_search]) if params[:user_address1_search].present?
+    @users = @users.order(birthday: :desc) if params[:birthday_sort] == "latest"
+    @users = @users.order(birthday: :asc) if params[:birthday_sort] == "oldest"
+    @users = @users.page(params[:page]).per(params[:per_page])
+  end
   
-    def show
-      @user = User.find(params[:id])
-    end
+  def show
+    @user = User.find(params[:id])
+  end
 end
   

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,11 @@ class User < ApplicationRecord
     validates :postcode, regex_postcode: true
     validates :hiragana_nama, regex_hiragana: true
 
+    # 検索機能でのスコープ
+    scope :search_name, -> (name){ where("name LIKE ?", "%#{name}%") if name.present? }
+    scope :search_address1, -> (address1){ where(address1: address1) if address1.present? }
+    scope :order_by, -> (order){ order(order) if order.present? }
+
     #性別enum使用
     enum sex: { '男性': 'male', '女性': 'female', 'その他': 'other', '回答なし': 'no_answer' }
     #都道府県enum使用

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,6 +1,21 @@
 <h1>従業員管理サイト</h1>
 <%= link_to "管理者画面", admin_users_path %><br/>
 
+<div class="search">
+  <h2>投稿検索</h2>
+    <%= form_with(url: users_path, method: :get) do |form| %>
+      <%= form.label :user_name_search, "名前を検索:" %>
+      <%= form.text_field :user_name_search %><br>
+      <%= form.label :user_address1_search, "都道府県を検索:" %>
+      <%= form.select :user_address1_search, User.address1s.keys, prompt: '都道府県を選択してください' %><br>
+      <%= form.label :birthday_sort, "誕生日で並び替え:" %>
+      <%= form.select :birthday_sort, { "誕生日(新しい順)" => "latest", "誕生日(古い順)" => "oldest" }, prompt: '並び替えを選択してください' %><br>
+      <%= form.label :per_page, "1ページあたりの項目数:" %>
+      <%= form.select :per_page, [10, 50, 100], prompt: '選択してください' %><br>
+      <%= form.submit '検索する' %>
+  <% end %>
+</div>
+
 <ul>
   <% @users.each do |user| %>
     <li>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -7,7 +7,7 @@
       <%= form.label :name, "名前を検索:" %>
       <%= form.text_field :name, value: params[:name]  %><br>
       <%= form.label :address1, "都道府県を検索:" %>
-      <%= form.select :address1, User.address1s, prompt: '都道府県を選択してください', selected: params[:address1]%><br>
+      <%= form.select :address1, @users.address1s, prompt: '都道府県を選択してください', selected: params[:address1]%><br>
       <%= form.label :birthday, "誕生日で並び替え:" %>
       <%= form.select :birthday, [["新しい順", "desc"], ["古い順", "asc"]], selected: params[:birthday]%><br>
       <%= form.label :per_page, "1ページあたりの項目数:" %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -4,14 +4,14 @@
 <div class="search">
   <h2>投稿検索</h2>
     <%= form_with(url: users_path, method: :get) do |form| %>
-      <%= form.label :user_name_search, "名前を検索:" %>
-      <%= form.text_field :user_name_search %><br>
-      <%= form.label :user_address1_search, "都道府県を検索:" %>
-      <%= form.select :user_address1_search, User.address1s.keys, prompt: '都道府県を選択してください' %><br>
-      <%= form.label :birthday_sort, "誕生日で並び替え:" %>
-      <%= form.select :birthday_sort, { "誕生日(新しい順)" => "latest", "誕生日(古い順)" => "oldest" }, prompt: '並び替えを選択してください' %><br>
+      <%= form.label :name, "名前を検索:" %>
+      <%= form.text_field :name, value: params[:name]  %><br>
+      <%= form.label :address1, "都道府県を検索:" %>
+      <%= form.select :address1, User.address1s, prompt: '都道府県を選択してください', selected: params[:address1]%><br>
+      <%= form.label :birthday, "誕生日で並び替え:" %>
+      <%= form.select :birthday, [["新しい順", "desc"], ["古い順", "asc"]], selected: params[:birthday]%><br>
       <%= form.label :per_page, "1ページあたりの項目数:" %>
-      <%= form.select :per_page, [10, 50, 100], prompt: '選択してください' %><br>
+      <%= form.select :per_page, [10, 50, 100], prompt: '選択してください', selected: params[:per_page] %><br>
       <%= form.submit '検索する' %>
   <% end %>
 </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -5,13 +5,13 @@
   <h2>投稿検索</h2>
     <%= form_with(url: users_path, method: :get) do |form| %>
       <%= form.label :name, "名前を検索:" %>
-      <%= form.text_field :name, value: params[:name]  %><br>
+      <%= form.text_field :name, value: @name  %><br>
       <%= form.label :address1, "都道府県を検索:" %>
-      <%= form.select :address1, @users.address1s, prompt: '都道府県を選択してください', selected: params[:address1]%><br>
-      <%= form.label :birthday, "誕生日で並び替え:" %>
-      <%= form.select :birthday, [["新しい順", :desc], ["古い順", :asc]], selected: params[:birthday]%><br>
+      <%= form.select :address1, @users.address1s, prompt: '都道府県を選択してください', selected: @address1%><br>
+      <%= form.label :order, "誕生日で並び替え:" %>
+      <%= form.select :order, [["新しい順", 'birthday DESC'], ["古い順", 'birthday ASC']], selected: @order%><br>
       <%= form.label :per_page, "1ページあたりの項目数:" %>
-      <%= form.select :per_page, [10, 50, 100], prompt: '選択してください', selected: params[:per_page] %><br>
+      <%= form.select :per_page, [10, 50, 100], prompt: '選択してください', selected: @per_page %><br>
       <%= form.submit '検索する' %>
   <% end %>
 </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -9,7 +9,7 @@
       <%= form.label :address1, "都道府県を検索:" %>
       <%= form.select :address1, @users.address1s, prompt: '都道府県を選択してください', selected: params[:address1]%><br>
       <%= form.label :birthday, "誕生日で並び替え:" %>
-      <%= form.select :birthday, [["新しい順", "desc"], ["古い順", "asc"]], selected: params[:birthday]%><br>
+      <%= form.select :birthday, [["新しい順", :desc], ["古い順", :asc]], selected: params[:birthday]%><br>
       <%= form.label :per_page, "1ページあたりの項目数:" %>
       <%= form.select :per_page, [10, 50, 100], prompt: '選択してください', selected: params[:per_page] %><br>
       <%= form.submit '検索する' %>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 Kaminari.configure do |config|
-  config.default_per_page = 25
-  config.max_per_page = 25
+  config.default_per_page = 10
+  config.max_per_page = 100
   # config.window = 4
   # config.outer_window = 0
   # config.left = 0

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -12,6 +12,41 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     Rails.cache.clear
   end
 
+  test "ユーザー名を検索が成功していること" do
+    get users_path, params: { name: @user.name }
+    assert_response :success
+  end
+
+  test "住所を検索が成功していること" do
+    get users_path, params: { address1: @user.address1 }
+    assert_response :success
+  end
+
+  test "誕生日を降順検索が成功していること" do
+    get users_path, params: { birthday: 'desc' }
+    assert_response :success
+  end
+
+  test "誕生日を昇順検索が成功していること" do
+    get users_path, params: { birthday: 'asc' }
+    assert_response :success
+  end
+
+  test "1ページあたり 10個表示させる" do
+    get users_path, params: { per_page: 10 }
+    assert_response :success
+  end
+
+  test "1ページあたり50個表示させる" do
+    get users_path, params: { per_page: 50 }
+    assert_response :success
+  end
+
+  test "1ページあたり100個表示させる" do
+    get users_path, params: { per_page: 100 }
+    assert_response :success
+  end
+
   test "新しいユーザーの登録がデータベースに反映され、データ数が増加していること" do
     assert_difference("User.count",+1) do
       post admin_users_url, params: {

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -23,12 +23,12 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "誕生日を降順検索が成功していること" do
-    get users_path, params: { birthday: 'desc' }
+    get users_path, params: { birthday: :desc }
     assert_response :success
   end
 
   test "誕生日を昇順検索が成功していること" do
-    get users_path, params: { birthday: 'asc' }
+    get users_path, params: { birthday: :asc }
     assert_response :success
   end
 


### PR DESCRIPTION
### What （概要）
一般公開ページで次の検索、絞り込みをできるようにしてください。
・名前で選択
・都道府県で絞り込み
・誕生日順でソート（昇順、降順）
・per_pageは10, 50, 100をユーザーが選べるようにし、100が上限なのは設定ファイル化してください。

### Why（開発・変更する理由）
従業員を検索で出力することでサイトの利便性を高めるため

### How（どのように実装したのか）
名前：検索機能実装
都道府県：絞り込み（enumを使用する）
誕生日：ソート実装
従業員数：設定ファイル（Kaminari）

### 非対応内容
テスティング

### before/after（ステージングURLや画像）
<img width="373" alt="スクリーンショット 2024-02-29 14 18 32" src="https://github.com/Rizap-tomoki/RailsTraining/assets/128169244/738b9491-3a0f-4c66-b3a7-bec4cbd0ead2">

