### PR TITLE
[issues/60] VueでRailsで作成したAPIを呼び出すためにCORS設定を行った

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,3 +87,4 @@ gem 'bootstrap5-kaminari-views', '~> 0.0.1'
 
 gem 'omniauth-google-oauth2'
 gem 'omniauth-rails_csrf_protection'
+gem 'rack-cors', require: 'rack/cors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -217,6 +217,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.7.1)
     rack (2.2.8)
+    rack-cors (2.0.2)
+      rack (>= 2.0.0)
     rack-protection (3.2.0)
       base64 (>= 0.1.0)
       rack (~> 2.2, >= 2.2.4)
@@ -366,6 +368,7 @@ DEPENDENCIES
   omniauth-rails_csrf_protection
   pry-rails
   puma (~> 5.0)
+  rack-cors
   rails (~> 7.0.5)
   rspec-rails (~> 4.0.1)
   rubocop

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,5 +18,14 @@ module Myapp
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+    # CORS設定を追加
+    config.middleware.insert_before 0, Rack::Cors do
+      allow do
+        origins 'http://localhost:5173' # フロントエンドのURLを指定
+        resource '*',
+          headers: :any,
+          methods: [:get, :post, :put, :patch, :delete, :options, :head]
+      end
+    end
   end
 end


### PR DESCRIPTION
### What （概要）
VueでRailsで作成したAPIを呼び出すためにCORS設定を行った

### Why（開発・変更する理由）
特定のオリジンからのリクエストを許可するためにCORSを設定

### How（どのように実装したのか）
Gemをインストール
gem 'rack-cors', require: 'rack/cors'
`Rack::Cors`ミドルウェアで条件を設定

### 非対応内容

### before/after（ステージングURLや画像）
